### PR TITLE
Officially support python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
 
     steps:
@@ -30,7 +30,7 @@ jobs:
         codecov -X gcov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      if: matrix.python-version == 3.8
+      if: matrix.python-version == 3.9
 
   lint:
 
@@ -45,7 +45,7 @@ jobs:
     - name: Set up python3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Text Processing",
         "Topic :: Text Processing :: Markup :: LaTeX",
     ],


### PR DESCRIPTION
This has always worked, but we now also run the CI against python 3.9 and have the appropriate classifier in `setup.py`.